### PR TITLE
add-apt-repository command installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:trusty
 MAINTAINER Helmi Ibrahim <helmi@tuxuri.com>
 
+RUN apt-get -y install software-properties-common python-software-properties
 RUN add-apt-repository ppa:ubuntugis/ubuntugis-unstable
 RUN echo "deb http://archive.ubuntu.com/ubuntu trusty main universe" > /etc/apt/sources.list
 RUN apt-get -y update


### PR DESCRIPTION
add-apt-repository command is throwing code 127 which means command not found.
adding required installation command
